### PR TITLE
Feat/criar card lirtugy view

### DIFF
--- a/Macro02/Macro02.xcodeproj/project.pbxproj
+++ b/Macro02/Macro02.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AF9C0FDD2CA1E5F3008187EC /* TextComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9C0FD82CA1E5F3008187EC /* TextComponent.swift */; };
 		AFC683B72CA48B7900389DD8 /* LiturgiaDiariaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC683B62CA48B7900389DD8 /* LiturgiaDiariaAPI.swift */; };
 		AFC862112CA32A7100167ECB /* ButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC862102CA32A7100167ECB /* ButtonComponent.swift */; };
+		AFF9FA3D2CAF13D1004AB04F /* LiturgyCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF9FA3C2CAF13D1004AB04F /* LiturgyCardView.swift */; };
 		B84DEA082CA48F900010CEBC /* SinViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84DEA072CA48F900010CEBC /* SinViewModel.swift */; };
 		B8783F822C99F32E00661148 /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8783F812C99F32E00661148 /* CoordinatorProtocol.swift */; };
 		B8783F842C99F43800661148 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8783F832C99F43300661148 /* ViewModel.swift */; };
@@ -81,6 +82,7 @@
 		AF9C0FD82CA1E5F3008187EC /* TextComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextComponent.swift; sourceTree = "<group>"; };
 		AFC683B62CA48B7900389DD8 /* LiturgiaDiariaAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiturgiaDiariaAPI.swift; sourceTree = "<group>"; };
 		AFC862102CA32A7100167ECB /* ButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponent.swift; sourceTree = "<group>"; };
+		AFF9FA3C2CAF13D1004AB04F /* LiturgyCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiturgyCardView.swift; sourceTree = "<group>"; };
 		B84DEA072CA48F900010CEBC /* SinViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinViewModel.swift; sourceTree = "<group>"; };
 		B8783F812C99F32E00661148 /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
 		B8783F832C99F43300661148 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 		AF9C0FD92CA1E5F3008187EC /* TextComponents  */ = {
 			isa = PBXGroup;
 			children = (
+				AFF9FA3C2CAF13D1004AB04F /* LiturgyCardView.swift */,
 				AFC862102CA32A7100167ECB /* ButtonComponent.swift */,
 				AF9C0FD62CA1E5F3008187EC /* FontStyle.swift */,
 				AF9C0FD72CA1E5F3008187EC /* setDynamicFont.swift */,
@@ -508,6 +511,7 @@
 				F1F6BE432C99FDD700F4C7FF /* ApplicationCoordinator.swift in Sources */,
 				F1F6BE652C9B5DE600F4C7FF /* BibleViewController.swift in Sources */,
 				F1EDE14A2C9CD045007A6403 /* CounsciousnessExamCoordinator.swift in Sources */,
+				AFF9FA3D2CAF13D1004AB04F /* LiturgyCardView.swift in Sources */,
 				B8783F902C99F63A00661148 /* DataModel.xcdatamodeld in Sources */,
 				F1F6BE742C9B644C00F4C7FF /* ConfessionViewModel.swift in Sources */,
 				AFC683B72CA48B7900389DD8 /* LiturgiaDiariaAPI.swift in Sources */,

--- a/Macro02/Macro02/Model/LiturgiaDiariaAPI.swift
+++ b/Macro02/Macro02/Model/LiturgiaDiariaAPI.swift
@@ -77,7 +77,7 @@ class APIManager {
             // Tenta converter os dados recebidos para JSON e imprimir
             do {
                 if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    print("Resposta JSON da API: \(json)")
+//                    print("Resposta JSON da API: \(json)")
                 } else {
                     print("A resposta não é um dicionário JSON.")
                 }

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -63,7 +63,7 @@ class LiturgyCardView: UIView {
         dayNameLabel.text = liturgia.dia
         dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
         monthNameLabel.text = liturgia.data ?? "no monthNameLabel"
-        yearNumberLabel.text = "\(liturgia.data) / \(liturgia.data)"
+        yearNumberLabel.text = "\(liturgia.data ?? "liturgy data not found") / \(liturgia.data ?? "Litugy data not found")"
         self.dataLiturgia = liturgia.data ?? "no data"
         
         // Atualiza com base na dataLiturgia

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -19,10 +19,10 @@ import UIKit
 
 class LiturgyCardView: UIView {
     
-    private let weekLabel = UILabel()
-    private let dayNameLabel = UILabel()
-    private let dayNumberLabel = UILabel()
-    private let monthYearLabel = UILabel()
+    private let weekLabel = TextComponent()
+    private let dayNameLabel = TextComponent()
+    private let dayNumberLabel = TextComponent()
+    private let monthYearLabel = TextComponent()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -57,6 +57,8 @@ class LiturgyCardView: UIView {
     }
     
     func update(with liturgia: Liturgia) {
+        
+        //NOTE: NÃO SEI PORQUE MAS SE APAGAR ESTAS 6 LINHAS DE CÓDIGO O COMPONENTE PARA DE FUNCIONAR, NÃO APAGUE
         weekNumberLabel.text = liturgia.data ?? "no data week label"
         dayNameLabel.text = liturgia.dia
         dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
@@ -75,7 +77,7 @@ class LiturgyCardView: UIView {
 
     }
     
-    /// Retorna para obter o nome do dia da semana
+    /// Retorna o dia da semana em String, permite escolher a quantidade de caracteres do dia da semana
     private func getWeekdayName(from dateString: String, length: Int) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "dd-MM-yyyy"

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -12,14 +12,15 @@ import UIKit
 /// O card contém as seguintes informações:
 /// - Semana atual da liturgia exibida no `weekNumberLabel`.
 /// - Dia da semana atual em formato de texto no `dayNameLabel`.
-/// - Dia da liturggia em formado de número `dayNameLabel`
-/// - Dia da liturgia em formato de número `yearNumberLabel`
+/// - Dia da liturgia em formato de número no `dayNumberLabel`.
 /// - Mês em formato de texto no `monthNameLabel`.
 /// - Ano no formato de número em `yearNumberLabel`.
 ///
 /// Este componente é utilizado no protótipo de média na View de liturgia para exibir dados relacionados à data.
 
 class LiturgyCardView: UIView {
+    
+    private var dataLiturgia = String()
         
     private let weekNumberLabel = TextComponent()
     private let dayNameLabel = TextComponent()
@@ -47,17 +48,47 @@ class LiturgyCardView: UIView {
         addSubview(weekNumberLabel)
         addSubview(dayNameLabel)
         addSubview(dayNumberLabel)
+        addSubview(monthNameLabel)
         addSubview(yearNumberLabel)
-    }
-    
-    private func constrains() {
         
+        setConstraints()
     }
     
     func update(with liturgia: Liturgia) {
         weekNumberLabel.text = liturgia.data ?? "no data week label"
         dayNameLabel.text = liturgia.dia
         dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
+        monthNameLabel.text = liturgia.data ?? "no monthNameLabel"
         yearNumberLabel.text = "\(liturgia.data) / \(liturgia.data)"
+        self.dataLiturgia = liturgia.data ?? "no data"
+        print(self.dataLiturgia)
+    }
+}
+
+extension LiturgyCardView {
+    private func setConstraints() {
+        weekNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        dayNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        dayNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        monthNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        yearNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            weekNumberLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 16),
+            weekNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            dayNameLabel.topAnchor.constraint(equalTo: weekNumberLabel.bottomAnchor, constant: 8),
+            dayNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            dayNumberLabel.topAnchor.constraint(equalTo: dayNameLabel.bottomAnchor, constant: 8),
+            dayNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            monthNameLabel.topAnchor.constraint(equalTo: dayNumberLabel.bottomAnchor, constant: 8),
+            monthNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            yearNumberLabel.topAnchor.constraint(equalTo: monthNameLabel.bottomAnchor, constant: 8),
+            yearNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            yearNumberLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
+        ])
     }
 }

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -7,6 +7,16 @@
 
 import UIKit
 
+/// Card que exibe informações da liturgia na `LiturgyView`.
+///
+/// O card contém as seguintes informações:
+/// - Semana atual da liturgia exibida no `weekLabel`.
+/// - Dia da semana atual em formato de texto no `dayNameLabel`.
+/// - Dia do mês em formato numérico no `dayNumberLabel`.
+/// - Mês abreviado e ano completo no `monthYearLabel`.
+///
+/// Este componente é utilizado no protótipo de média na View de liturgia para exibir dados relacionados à data.
+
 class LiturgyCardView: UIView {
     
     private let weekLabel = UILabel()

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -1,0 +1,44 @@
+//
+//  LiturgyCardView.swift
+//  Macro02
+//
+//  Created by Thiago Pereira de Menezes on 03/10/24.
+//
+
+import UIKit
+
+class LiturgyCardView: UIView {
+    
+    private let weekLabel = UILabel()
+    private let dayNameLabel = UILabel()
+    private let dayNumberLabel = UILabel()
+    private let monthYearLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        backgroundColor = .white
+        layer.cornerRadius = 8
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.black.cgColor
+        
+        addSubview(weekLabel)
+        addSubview(dayNameLabel)
+        addSubview(dayNumberLabel)
+        addSubview(monthYearLabel)
+    }
+    
+    func update(with liturgia: Liturgia) {
+        weekLabel.text = liturgia.data ?? "no data week label"
+        dayNameLabel.text = liturgia.dia
+        dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
+        monthYearLabel.text = "\(liturgia.data) / \(liturgia.data)"
+    }
+}

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -21,14 +21,14 @@ import UIKit
 class LiturgyCardView: UIView {
     
     private var dataLiturgia = String()
-        
+    
     private let weekNumberLabel = TextComponent()
     private let dayNameLabel = TextComponent()
     
     private let dayNumberLabel = TextComponent()
     private let monthNameLabel = TextComponent()
     private let yearNumberLabel = TextComponent()
-    private let colorLiturgy = UIColor()
+    private var colorLiturgy = UIColor()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -45,6 +45,8 @@ class LiturgyCardView: UIView {
         layer.borderWidth = 1
         layer.borderColor = UIColor.black.cgColor
         
+        self.weekNumberLabel.setDynamicFont(size: 14, weight: .bold)
+        self.dayNumberLabel.font = UIFont.setCustomFont(.titulo1)
         addSubview(weekNumberLabel)
         addSubview(dayNameLabel)
         addSubview(dayNumberLabel)
@@ -61,33 +63,128 @@ class LiturgyCardView: UIView {
         monthNameLabel.text = liturgia.data ?? "no monthNameLabel"
         yearNumberLabel.text = "\(liturgia.data) / \(liturgia.data)"
         self.dataLiturgia = liturgia.data ?? "no data"
-        print(self.dataLiturgia)
+        
+        // Atualiza com base na dataLiturgia
+        self.weekNumberLabel.text = "23º Semana do Tempo Comum"
+        self.dayNameLabel.text = getWeekdayName(from: dataLiturgia, length: 3)
+        self.dayNumberLabel.text = getDayNumber(from: dataLiturgia)
+        self.monthNameLabel.text = getMonthName(from: dataLiturgia)
+        self.yearNumberLabel.text = getYearNumber(from: dataLiturgia)
+        self.colorLiturgy = colorFromString(liturgia.cor ?? "😳")
+        self.weekNumberLabel.textColor = self.colorLiturgy
+
     }
+    
+    /// Retorna para obter o nome do dia da semana
+    private func getWeekdayName(from dateString: String, length: Int) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd-MM-yyyy"
+        guard let date = dateFormatter.date(from: dateString) else {
+            return "Invalid Date"
+        }
+        
+        dateFormatter.dateFormat = "EEEE" // Formato completo do dia da semana
+        let fullWeekday = dateFormatter.string(from: date)
+        
+        return String(fullWeekday.prefix(length)) // Retorna o nome com a quantidade de caracteres desejada
+    }
+    
+    /// Retorna o nome do mês, recebe data como parametro
+    private func getMonthName(from dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd-MM-yyyy"
+        guard let date = dateFormatter.date(from: dateString) else {
+            return "Invalid Date"
+        }
+        
+        dateFormatter.dateFormat = "MMM" // Abreviação de 3 caracteres do mês
+        return dateFormatter.string(from: date)
+    }
+    
+    /// Função que retorna o número do mês, recebe uma data como parâmetro
+    private func getMonthNumber(from dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd-MM-yyyy"
+        guard let date = dateFormatter.date(from: dateString) else {
+            return "Invalid Date"
+        }
+        
+        dateFormatter.dateFormat = "MM" // Número do mês
+        return dateFormatter.string(from: date)
+    }
+    
+    /// Recebe uma data no formato dd-MM-yyyy e retorna apenas o ano "yyyy"
+    private func getYearNumber(from dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd-MM-yyyy"
+        guard let date = dateFormatter.date(from: dateString) else {
+            return "Invalid Date"
+        }
+        
+        dateFormatter.dateFormat = "yyyy" // Número do ano completo
+        return dateFormatter.string(from: date)
+    }
+    
+    /// Recebe uma data no formato dd-MM-yyyy e retorna apenas o dia "dd"
+    private func getDayNumber(from dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd-MM-yyyy" // Formato esperado da data
+        guard let date = dateFormatter.date(from: dateString) else {
+            return "Invalid Date"
+        }
+        
+        dateFormatter.dateFormat = "dd" // Formato para obter apenas o dia
+        return dateFormatter.string(from: date)
+    }
+    
+    /// Converte o parametro Liturgia.cor  para uma UIcolor
+    private func colorFromString(_ colorName: String) -> UIColor {
+        switch colorName.lowercased() {
+        case "verde":
+            return UIColor.green
+        case "branco":
+            return UIColor.white
+        case "vermelho":
+            return UIColor.red
+        case "roxo":
+            return UIColor.purple
+        case "preto":
+            return UIColor.black
+        case "rosa":
+            return UIColor.systemPink
+        default:
+            return UIColor.white
+        }
+    }
+    
 }
 
 extension LiturgyCardView {
     private func setConstraints() {
-        weekNumberLabel.translatesAutoresizingMaskIntoConstraints = false
-        dayNameLabel.translatesAutoresizingMaskIntoConstraints = false
-        dayNumberLabel.translatesAutoresizingMaskIntoConstraints = false
-        monthNameLabel.translatesAutoresizingMaskIntoConstraints = false
-        yearNumberLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
+            // Alinha weekNumberLabel ao topo superior esquerdo
             weekNumberLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 16),
             weekNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
             
-            dayNameLabel.topAnchor.constraint(equalTo: weekNumberLabel.bottomAnchor, constant: 8),
-            dayNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            // Alinhando o dayNameLabel abaixo do weekNumberLabel
+            dayNameLabel.topAnchor.constraint(equalTo: weekNumberLabel.bottomAnchor),
+            dayNameLabel.leadingAnchor.constraint(equalTo: weekNumberLabel.leadingAnchor),
             
-            dayNumberLabel.topAnchor.constraint(equalTo: dayNameLabel.bottomAnchor, constant: 8),
-            dayNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            // Posiciona o monthNameLabel ao topo superior direito
+            monthNameLabel.topAnchor.constraint(equalTo: self.topAnchor),
+            monthNameLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 8),
             
-            monthNameLabel.topAnchor.constraint(equalTo: dayNumberLabel.bottomAnchor, constant: 8),
-            monthNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            // Posiciona o yearNumberLabel abaixo do monthNameLabel
+            yearNumberLabel.topAnchor.constraint(equalTo: monthNameLabel.bottomAnchor),
+            yearNumberLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 8),
             
-            yearNumberLabel.topAnchor.constraint(equalTo: monthNameLabel.bottomAnchor, constant: 8),
-            yearNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            // Posiciona o dayNumberLabel à esquerda do monthNameLabel
+            dayNumberLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            dayNumberLabel.trailingAnchor.constraint(equalTo: monthNameLabel.leadingAnchor, constant: 8),
+            
+            // Definindo a altura e a distância inferior
             yearNumberLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
     }

--- a/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
+++ b/Macro02/Macro02/Utils/TextComponents /LiturgyCardView.swift
@@ -10,19 +10,24 @@ import UIKit
 /// Card que exibe informações da liturgia na `LiturgyView`.
 ///
 /// O card contém as seguintes informações:
-/// - Semana atual da liturgia exibida no `weekLabel`.
+/// - Semana atual da liturgia exibida no `weekNumberLabel`.
 /// - Dia da semana atual em formato de texto no `dayNameLabel`.
-/// - Dia do mês em formato numérico no `dayNumberLabel`.
-/// - Mês abreviado e ano completo no `monthYearLabel`.
+/// - Dia da liturggia em formado de número `dayNameLabel`
+/// - Dia da liturgia em formato de número `yearNumberLabel`
+/// - Mês em formato de texto no `monthNameLabel`.
+/// - Ano no formato de número em `yearNumberLabel`.
 ///
 /// Este componente é utilizado no protótipo de média na View de liturgia para exibir dados relacionados à data.
 
 class LiturgyCardView: UIView {
-    
-    private let weekLabel = TextComponent()
+        
+    private let weekNumberLabel = TextComponent()
     private let dayNameLabel = TextComponent()
+    
     private let dayNumberLabel = TextComponent()
-    private let monthYearLabel = TextComponent()
+    private let monthNameLabel = TextComponent()
+    private let yearNumberLabel = TextComponent()
+    private let colorLiturgy = UIColor()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -39,16 +44,20 @@ class LiturgyCardView: UIView {
         layer.borderWidth = 1
         layer.borderColor = UIColor.black.cgColor
         
-        addSubview(weekLabel)
+        addSubview(weekNumberLabel)
         addSubview(dayNameLabel)
         addSubview(dayNumberLabel)
-        addSubview(monthYearLabel)
+        addSubview(yearNumberLabel)
+    }
+    
+    private func constrains() {
+        
     }
     
     func update(with liturgia: Liturgia) {
-        weekLabel.text = liturgia.data ?? "no data week label"
+        weekNumberLabel.text = liturgia.data ?? "no data week label"
         dayNameLabel.text = liturgia.dia
         dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
-        monthYearLabel.text = "\(liturgia.data) / \(liturgia.data)"
+        yearNumberLabel.text = "\(liturgia.data) / \(liturgia.data)"
     }
 }

--- a/Macro02/Macro02/ViewController/DailyLiturgyViewController.swift
+++ b/Macro02/Macro02/ViewController/DailyLiturgyViewController.swift
@@ -173,39 +173,3 @@ extension DailyLiturgyViewController {
 
 }
 
-// MARK: - LiturgyCardView
-class LiturgyCardView: UIView {
-    
-    private let weekLabel = UILabel()
-    private let dayNameLabel = UILabel()
-    private let dayNumberLabel = UILabel()
-    private let monthYearLabel = UILabel()
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setupView()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupView() {
-        backgroundColor = .white
-        layer.cornerRadius = 8
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.black.cgColor
-        
-        addSubview(weekLabel)
-        addSubview(dayNameLabel)
-        addSubview(dayNumberLabel)
-        addSubview(monthYearLabel)
-    }
-    
-    func update(with liturgia: Liturgia) {
-        weekLabel.text = liturgia.data ?? "no data week label"
-        dayNameLabel.text = liturgia.dia
-        dayNumberLabel.text = liturgia.data ?? "no dayNumberLabel"
-        monthYearLabel.text = "\(liturgia.data) / \(liturgia.data)"
-    }
-}


### PR DESCRIPTION

- Adiciona o layout básico da `DailyLiturgyViewController` com componentes de texto e botão personalizados.
- Implementa suporte a StringLocalization e Dynamic Types para os textos.
- Integra o manager de requisições API para obter dados de liturgia diária.
- Adiciona funcionalidades de navegação com botão de voltar customizado.
- Realiza ajustes de layout e testes de responsividade.